### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/adsp.freesurround/addon.xml.in
+++ b/adsp.freesurround/addon.xml.in
@@ -10,17 +10,13 @@
 	</requires>
 	<extension
 		point="kodi.adsp"
-		library_linux="adsp.freesurround.so"
-		library_osx="adsp.freesurround.dylib"
-		library_wingl="adsp.freesurround.dll"
-		library_windx="adsp.freesurround.dll"
-		library_android="libadsp.freesurround.so" />
+		library_@PLATFORM@="@LIBRARY_FILENAME@"/>
 	<extension point="kodi.addon.metadata">
 		<summary lang="en">Free Surround Audio DSP Processor</summary>
 		<description lang="en">FreeSurround is meant to be the KODI equivalent of your hi-fi receiver's Dolby ProLogic II button.
 It's purpose is to decode surround information from your stereo music and to produce multichannel output from it.</description>
 		<disclaimer lang="en">This is a open source audio dsp processing system, based upon work from pro_optimizer on foobar2000</disclaimer>
-		<platform>all</platform>
+		<platform>@PLATFORM@</platform>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
 		<forum>http://forum.kodi.tv/forumdisplay.php?fid=235</forum>
 		<website></website>

--- a/src/ChannelMaps.h
+++ b/src/ChannelMaps.h
@@ -28,7 +28,7 @@
 #include <vector>
 #include <map>
 
-#include "kodi/kodi_adsp_types.h"
+#include "kodi_adsp_types.h"
 
 /*
  * Identifier translation from FreeSurround to KODI ADSP

--- a/src/DSPProcessFreeSurround.cpp
+++ b/src/DSPProcessFreeSurround.cpp
@@ -22,8 +22,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
 #include "p8-platform/util/StdString.h"
 
 #include "addon.h"

--- a/src/DSPProcessFreeSurround.h
+++ b/src/DSPProcessFreeSurround.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <map>
 
-#include "kodi/kodi_adsp_types.h"
+#include "kodi_adsp_types.h"
 #include "FreeSurroundDecoder.h"
 #include "FreeSurroundSettings.h"
 

--- a/src/FreeSurroundSettings.cpp
+++ b/src/FreeSurroundSettings.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 

--- a/src/GUIDialogFreeSurround.cpp
+++ b/src/GUIDialogFreeSurround.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 
 #include "GUIDialogFreeSurround.h"

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <string>
 #include "addon.h"
-#include "kodi/kodi_adsp_dll.h"
+#include "kodi_adsp_dll.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 #include "GUIDialogFreeSurround.h"

--- a/src/addon.h
+++ b/src/addon.h
@@ -18,9 +18,9 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
 class CDSPProcess_FreeSurround;
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in
