### PR TITLE
fix seg faults if back channels are used instead of side

### DIFF
--- a/adsp.freesurround/addon.xml.in
+++ b/adsp.freesurround/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
 	id="adsp.freesurround"
-	version="0.2.1"
+	version="0.2.2"
 	name="Free Surround Processor"
 	provider-name="Team KODI">
 	<requires>

--- a/src/ChannelMaps.cpp
+++ b/src/ChannelMaps.cpp
@@ -2854,25 +2854,49 @@ bool init_maps() {
     chn_alloc[cs_5stereo].push_back(std::vector<float*>(&map_5stereo_rcf[0],&map_5stereo_rcf[21]));
     chn_alloc[cs_5stereo].push_back(std::vector<float*>(&map_5stereo_rf[0],&map_5stereo_rf[21]));
     chn_alloc[cs_5stereo].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
-    chn_angle[cs_4point1] = std::vector<float>(&map_4point1_ang[0],&map_4point1_ang[sizeof(map_4point1_ang)/sizeof(map_4point1_ang[0])]);
-    chn_xsf[cs_4point1] = std::vector<float>(&map_4point1_xsf[0],&map_4point1_xsf[sizeof(map_4point1_xsf)/sizeof(map_4point1_xsf[0])]);
-    chn_ysf[cs_4point1] = std::vector<float>(&map_4point1_ysf[0],&map_4point1_ysf[sizeof(map_4point1_ysf)/sizeof(map_4point1_ysf[0])]);
-    chn_id[cs_4point1] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_4point1_id[0],&map_4point1_id[sizeof(map_4point1_id)/sizeof(map_4point1_id[0])]);
-    chn_alloc[cs_4point1].push_back(std::vector<float*>(&map_4point1_lf[0],&map_4point1_lf[21]));
-    chn_alloc[cs_4point1].push_back(std::vector<float*>(&map_4point1_rf[0],&map_4point1_rf[21]));
-    chn_alloc[cs_4point1].push_back(std::vector<float*>(&map_4point1_ls[0],&map_4point1_ls[21]));
-    chn_alloc[cs_4point1].push_back(std::vector<float*>(&map_4point1_rs[0],&map_4point1_rs[21]));
-    chn_alloc[cs_4point1].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
-    chn_angle[cs_5point1] = std::vector<float>(&map_5point1_ang[0],&map_5point1_ang[sizeof(map_5point1_ang)/sizeof(map_5point1_ang[0])]);
-    chn_xsf[cs_5point1] = std::vector<float>(&map_5point1_xsf[0],&map_5point1_xsf[sizeof(map_5point1_xsf)/sizeof(map_5point1_xsf[0])]);
-    chn_ysf[cs_5point1] = std::vector<float>(&map_5point1_ysf[0],&map_5point1_ysf[sizeof(map_5point1_ysf)/sizeof(map_5point1_ysf[0])]);
-    chn_id[cs_5point1] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_5point1_id[0],&map_5point1_id[sizeof(map_5point1_id)/sizeof(map_5point1_id[0])]);
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_5point1_lf[0],&map_5point1_lf[21]));
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_5point1_cf[0],&map_5point1_cf[21]));
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_5point1_rf[0],&map_5point1_rf[21]));
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_5point1_ls[0],&map_5point1_ls[21]));
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_5point1_rs[0],&map_5point1_rs[21]));
-    chn_alloc[cs_5point1].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
+
+    chn_angle[cs_4point1_Side] = std::vector<float>(&map_4point1_ang[0],&map_4point1_ang[sizeof(map_4point1_ang)/sizeof(map_4point1_ang[0])]);
+    chn_xsf[cs_4point1_Side] = std::vector<float>(&map_4point1_xsf[0],&map_4point1_xsf[sizeof(map_4point1_xsf)/sizeof(map_4point1_xsf[0])]);
+    chn_ysf[cs_4point1_Side] = std::vector<float>(&map_4point1_ysf[0],&map_4point1_ysf[sizeof(map_4point1_ysf)/sizeof(map_4point1_ysf[0])]);
+    chn_id[cs_4point1_Side] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_4point1_id[0],&map_4point1_id[sizeof(map_4point1_id)/sizeof(map_4point1_id[0])]);
+    chn_alloc[cs_4point1_Side].push_back(std::vector<float*>(&map_4point1_lf[0],&map_4point1_lf[21]));
+    chn_alloc[cs_4point1_Side].push_back(std::vector<float*>(&map_4point1_rf[0],&map_4point1_rf[21]));
+    chn_alloc[cs_4point1_Side].push_back(std::vector<float*>(&map_4point1_ls[0],&map_4point1_ls[21]));
+    chn_alloc[cs_4point1_Side].push_back(std::vector<float*>(&map_4point1_rs[0],&map_4point1_rs[21]));
+    chn_alloc[cs_4point1_Side].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
+
+    chn_angle[cs_4point1_Back] = std::vector<float>(&map_4point1_ang[0],&map_4point1_ang[sizeof(map_4point1_ang)/sizeof(map_4point1_ang[0])]);
+    chn_xsf[cs_4point1_Back] = std::vector<float>(&map_4point1_xsf[0],&map_4point1_xsf[sizeof(map_4point1_xsf)/sizeof(map_4point1_xsf[0])]);
+    chn_ysf[cs_4point1_Back] = std::vector<float>(&map_4point1_ysf[0],&map_4point1_ysf[sizeof(map_4point1_ysf)/sizeof(map_4point1_ysf[0])]);
+    chn_id[cs_4point1_Back] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_4point1_id[0],&map_4point1_id[sizeof(map_4point1_id)/sizeof(map_4point1_id[0])]);
+    chn_alloc[cs_4point1_Back].push_back(std::vector<float*>(&map_4point1_lf[0],&map_4point1_lf[21]));
+    chn_alloc[cs_4point1_Back].push_back(std::vector<float*>(&map_4point1_rf[0],&map_4point1_rf[21]));
+    chn_alloc[cs_4point1_Back].push_back(std::vector<float*>(&map_4point1_ls[0],&map_4point1_ls[21]));
+    chn_alloc[cs_4point1_Back].push_back(std::vector<float*>(&map_4point1_rs[0],&map_4point1_rs[21]));
+    chn_alloc[cs_4point1_Back].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
+
+    chn_angle[cs_5point1_Side] = std::vector<float>(&map_5point1_ang[0],&map_5point1_ang[sizeof(map_5point1_ang)/sizeof(map_5point1_ang[0])]);
+    chn_xsf[cs_5point1_Side] = std::vector<float>(&map_5point1_xsf[0],&map_5point1_xsf[sizeof(map_5point1_xsf)/sizeof(map_5point1_xsf[0])]);
+    chn_ysf[cs_5point1_Side] = std::vector<float>(&map_5point1_ysf[0],&map_5point1_ysf[sizeof(map_5point1_ysf)/sizeof(map_5point1_ysf[0])]);
+    chn_id[cs_5point1_Side] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_5point1_id[0],&map_5point1_id[sizeof(map_5point1_id)/sizeof(map_5point1_id[0])]);
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_5point1_lf[0],&map_5point1_lf[21]));
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_5point1_cf[0],&map_5point1_cf[21]));
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_5point1_rf[0],&map_5point1_rf[21]));
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_5point1_ls[0],&map_5point1_ls[21]));
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_5point1_rs[0],&map_5point1_rs[21]));
+    chn_alloc[cs_5point1_Side].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
+
+    chn_angle[cs_5point1_Back] = std::vector<float>(&map_5point1_ang[0],&map_5point1_ang[sizeof(map_5point1_ang)/sizeof(map_5point1_ang[0])]);
+    chn_xsf[cs_5point1_Back] = std::vector<float>(&map_5point1_xsf[0],&map_5point1_xsf[sizeof(map_5point1_xsf)/sizeof(map_5point1_xsf[0])]);
+    chn_ysf[cs_5point1_Back] = std::vector<float>(&map_5point1_ysf[0],&map_5point1_ysf[sizeof(map_5point1_ysf)/sizeof(map_5point1_ysf[0])]);
+    chn_id[cs_5point1_Back] = std::vector<AE_DSP_CHANNEL_PRESENT>(&map_5point1_id[0],&map_5point1_id[sizeof(map_5point1_id)/sizeof(map_5point1_id[0])]);
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_5point1_lf[0],&map_5point1_lf[21]));
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_5point1_cf[0],&map_5point1_cf[21]));
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_5point1_rf[0],&map_5point1_rf[21]));
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_5point1_ls[0],&map_5point1_ls[21]));
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_5point1_rs[0],&map_5point1_rs[21]));
+    chn_alloc[cs_5point1_Back].push_back(std::vector<float*>(&map_lfe_lfe[0],&map_lfe_lfe[21]));
+
     chn_angle[cs_6point1] = std::vector<float>(&map_6point1_ang[0],&map_6point1_ang[sizeof(map_6point1_ang)/sizeof(map_6point1_ang[0])]);
     chn_xsf[cs_6point1] = std::vector<float>(&map_6point1_xsf[0],&map_6point1_xsf[sizeof(map_6point1_xsf)/sizeof(map_6point1_xsf[0])]);
     chn_ysf[cs_6point1] = std::vector<float>(&map_6point1_ysf[0],&map_6point1_ysf[sizeof(map_6point1_ysf)/sizeof(map_6point1_ysf[0])]);

--- a/src/DSPProcessFreeSurround.cpp
+++ b/src/DSPProcessFreeSurround.cpp
@@ -207,7 +207,7 @@ unsigned int CDSPProcess_FreeSurround::StreamProcess(float **array_in, float **a
         array_out[AE_DSP_CH_LFE][pos]   = outputs[5][m_ProcessBufferPos];
         break;
       }
-      case cs_4point1:
+      case cs_4point1_Side:
       {
         array_out[AE_DSP_CH_FL][pos]    = outputs[0][m_ProcessBufferPos];
         array_out[AE_DSP_CH_FR][pos]    = outputs[1][m_ProcessBufferPos];
@@ -216,13 +216,32 @@ unsigned int CDSPProcess_FreeSurround::StreamProcess(float **array_in, float **a
         array_out[AE_DSP_CH_LFE][pos]   = outputs[4][m_ProcessBufferPos];
         break;
       }
-      case cs_5point1:
+      case cs_4point1_Back:
+      {
+        array_out[AE_DSP_CH_FL][pos]    = outputs[0][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_FR][pos]    = outputs[1][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_BL][pos]    = outputs[2][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_BR][pos]    = outputs[3][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_LFE][pos]   = outputs[4][m_ProcessBufferPos];
+        break;
+      }
+      case cs_5point1_Side:
       {
         array_out[AE_DSP_CH_FL][pos]    = outputs[0][m_ProcessBufferPos];
         array_out[AE_DSP_CH_FC][pos]    = outputs[1][m_ProcessBufferPos];
         array_out[AE_DSP_CH_FR][pos]    = outputs[2][m_ProcessBufferPos];
         array_out[AE_DSP_CH_SL][pos]    = outputs[3][m_ProcessBufferPos];
         array_out[AE_DSP_CH_SR][pos]    = outputs[4][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_LFE][pos]   = outputs[5][m_ProcessBufferPos];
+        break;
+      }
+      case cs_5point1_Back:
+      {
+        array_out[AE_DSP_CH_FL][pos]    = outputs[0][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_FC][pos]    = outputs[1][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_FR][pos]    = outputs[2][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_BL][pos]    = outputs[3][m_ProcessBufferPos];
+        array_out[AE_DSP_CH_BR][pos]    = outputs[4][m_ProcessBufferPos];
         array_out[AE_DSP_CH_LFE][pos]   = outputs[5][m_ProcessBufferPos];
         break;
       }
@@ -372,12 +391,18 @@ unsigned int CDSPProcess_FreeSurround::StreamProcess(float **array_in, float **a
       case cs_legacy:
       default:
       {
-        array_out[AE_DSP_CH_FL][pos]    = outputs[0][m_ProcessBufferPos];
-        array_out[AE_DSP_CH_FC][pos]    = outputs[1][m_ProcessBufferPos];
-        array_out[AE_DSP_CH_FR][pos]    = outputs[2][m_ProcessBufferPos];
-        array_out[AE_DSP_CH_BL][pos]    = outputs[3][m_ProcessBufferPos];
-        array_out[AE_DSP_CH_BR][pos]    = outputs[4][m_ProcessBufferPos];
-        array_out[AE_DSP_CH_LFE][pos]   = outputs[5][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_FL])
+          array_out[AE_DSP_CH_FL][pos]  = outputs[0][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_FC])
+          array_out[AE_DSP_CH_FC][pos]  = outputs[1][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_FR])
+          array_out[AE_DSP_CH_FR][pos]  = outputs[2][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_BL])
+          array_out[AE_DSP_CH_BL][pos]  = outputs[3][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_BR])
+          array_out[AE_DSP_CH_BR][pos]  = outputs[4][m_ProcessBufferPos];
+        if (array_out[AE_DSP_CH_LFE])
+          array_out[AE_DSP_CH_LFE][pos] = outputs[5][m_ProcessBufferPos];
         break;
       }
     }

--- a/src/FreeSurroundDecoder.h
+++ b/src/FreeSurroundDecoder.h
@@ -39,8 +39,10 @@ typedef enum {
   cs_stereo = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_LFE,
   cs_3stereo = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_LFE,
   cs_5stereo = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FLOC | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FROC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_LFE,
-  cs_4point1 = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_LFE,
-  cs_5point1 = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_LFE,
+  cs_4point1_Side = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_LFE,
+  cs_4point1_Back = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_BL | AE_DSP_PRSNT_CH_BR | AE_DSP_PRSNT_CH_LFE,
+  cs_5point1_Side = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_LFE,
+  cs_5point1_Back = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_BL | AE_DSP_PRSNT_CH_BR | AE_DSP_PRSNT_CH_LFE,
   cs_6point1 = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_BC | AE_DSP_PRSNT_CH_LFE,
   cs_7point1 = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FR | AE_DSP_PRSNT_CH_SL | AE_DSP_PRSNT_CH_SR | AE_DSP_PRSNT_CH_BL | AE_DSP_PRSNT_CH_BR | AE_DSP_PRSNT_CH_LFE,
   cs_7point1_panorama = AE_DSP_PRSNT_CH_FL | AE_DSP_PRSNT_CH_FLOC | AE_DSP_PRSNT_CH_FC | AE_DSP_PRSNT_CH_FROC | AE_DSP_PRSNT_CH_FR |
@@ -83,7 +85,7 @@ public:
    *           than 5ms to 20ms since the granularity at which locations are decoded
    *           changes with this.
    */
-  CFreeSurroundDecoder(channel_setup setup=cs_5point1, unsigned blocksize=4096, unsigned int samplerate=48000);
+  CFreeSurroundDecoder(channel_setup setup=cs_5point1_Side, unsigned blocksize=4096, unsigned int samplerate=48000);
   ~CFreeSurroundDecoder();
 
   float ** getOutputBuffers();


### PR DESCRIPTION
On linux I has seg faults if as output a 4 or 5 channel is selected, reason was a fixed layout with only side channels in 4.1 or 5.1, with this change it checks also for use of back channel pointers.
