### PR TITLE
Fix high/low cutoff?

### DIFF
--- a/src/FreeSurroundDecoder.cpp
+++ b/src/FreeSurroundDecoder.cpp
@@ -82,8 +82,8 @@ CFreeSurroundDecoder::CFreeSurroundDecoder(channel_setup setup, unsigned blocksi
   m_CenterImage     = 1.0;
   m_FrontSeparation = 1.0;
   m_RearSeparation  = 1.0;
-  m_LowCutoff       = 40.0 / m_Samplerate / 2.0 * m_BufferSizeHalf;
-  m_HighCutoff      = 90.0 / m_Samplerate / 2.0 * m_BufferSizeHalf;
+  m_LowCutoff       = 40.0 / (m_Samplerate / 2.0) * m_BufferSizeHalf;
+  m_HighCutoff      = 90.0 / (m_Samplerate / 2.0) * m_BufferSizeHalf;
   m_UseLFE          = true;
 }
 
@@ -360,12 +360,12 @@ void CFreeSurroundDecoder::SetRearSeparation(float v)
 
 void CFreeSurroundDecoder::SetLowCutoff(float v)
 {
-  m_LowCutoff = v/m_Samplerate/2.0*m_BufferSizeHalf;
+  m_LowCutoff = v/(m_Samplerate/2.0)*m_BufferSizeHalf;
 }
 
 void CFreeSurroundDecoder::SetHighCutoff(float v)
 {
-  m_HighCutoff = v/m_Samplerate/2.0*m_BufferSizeHalf;
+  m_HighCutoff = v/(m_Samplerate/2.0)*m_BufferSizeHalf;
 }
 
 void CFreeSurroundDecoder::SetBassRedirection(bool v)


### PR DESCRIPTION
That's the way it was originally here, and it seems to make more sense as well.
https://hydrogenaud.io/index.php?topic=52235.0
now it's basically "cutoff = v / buffer time"